### PR TITLE
tolower on $annotateProgram assignment

### DIFF
--- a/runPipeline
+++ b/runPipeline
@@ -170,7 +170,7 @@ my $referenceGenome;
 my $genbankFile;
 my $gff3File;
 
-my $annotateProgram=$configuration->{annotateProgram}||"prokka";
+my $annotateProgram=lc($configuration->{annotateProgram})||"prokka";
 
 ($referenceGenome,$genbankFile,$gff3File)=&check_reference_genome(\@referenceGenome) if (@referenceGenome);
 


### PR DESCRIPTION
The annotateProgram config option is passed directly into `runAnnotation` which means mixed cases (e.g. Prokka) causes runAnnotation to call a binary called `Prokka`. `lc()` on the  $assembleProgram assignment solves this. 

Option checking for deciding which annotation program to use (lines 984-1002) is already case-insensitive and none of the RATT-related calls call the RATT binary directly so the casing doesn't matter for RATT (unlike prokka).  Converting the config option to lowercase on assignment allows for flexibility on config parameters.

